### PR TITLE
Update leven to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/zeke/similarity",
   "dependencies": {
-    "leven": "^1.0.1"
+    "leven": "^2.0.0"
   },
   "devDependencies": {
     "tap": "^0.4.13"


### PR DESCRIPTION
breaking change is not relevant: it's in the move of a command line tool
to another package.
